### PR TITLE
fix: 엔티티 외래키 제약 조건 및 삭제 규칙 추가

### DIFF
--- a/backend/src/main/java/com/todoservice/greencatsoftware/domain/project/domain/entity/Project.java
+++ b/backend/src/main/java/com/todoservice/greencatsoftware/domain/project/domain/entity/Project.java
@@ -23,7 +23,10 @@ public class Project extends SuperEntity {
 
     @NotNull(message = "color_id는 필수 입니다.")
     @OneToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "color_id", nullable = false)
+    @JoinColumn(
+            name = "color_id", nullable = false,
+            foreignKey = @ForeignKey(name = "FK_PROJECT_COLOR")
+    )
     private Color color;
 
     @NotNull(message = "프로젝트 이름은 필수 입니다.")

--- a/backend/src/main/java/com/todoservice/greencatsoftware/domain/task/domain/entity/Task.java
+++ b/backend/src/main/java/com/todoservice/greencatsoftware/domain/task/domain/entity/Task.java
@@ -14,6 +14,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -25,7 +27,9 @@ public class Task extends SuperEntity {
 
     @NotNull(message = "프로젝트 id는 필수 입니다.")
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id", nullable = false)
+    @JoinColumn(name = "project_id", nullable = false,
+            foreignKey = @ForeignKey(name = "FK_TASK_PROJECT"))
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Project project;
 
     @NotNull(message = "priority는 필수 입니다.")

--- a/backend/src/main/java/com/todoservice/greencatsoftware/domain/task/domain/entity/Task.java
+++ b/backend/src/main/java/com/todoservice/greencatsoftware/domain/task/domain/entity/Task.java
@@ -6,7 +6,6 @@ import com.todoservice.greencatsoftware.common.enums.Priority;
 import com.todoservice.greencatsoftware.common.enums.Status;
 import com.todoservice.greencatsoftware.common.exception.BaseException;
 import com.todoservice.greencatsoftware.common.superEntity.SuperEntity;
-import com.todoservice.greencatsoftware.domain.color.entity.Color;
 import com.todoservice.greencatsoftware.domain.project.domain.entity.Project;
 import com.todoservice.greencatsoftware.domain.task.domain.vo.Schedule;
 import jakarta.persistence.*;


### PR DESCRIPTION
## 개요
1. Project 엔티티에 외래키 제약 조건(FK_PROJECT_COLOR) 추가한다.
2. Task 엔티티에 외래키 제약 조건(FK_TASK_PROJECT) 및 OnDelete 규칙(CASCADE) 추가한다.

Resolves #130

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/Git-1a10cae5674e813f8c60ebb4a8f99ca4?pvs=4#1aa0cae5674e807aa012d921c8fa6fe4) 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
