### PR TITLE
fix: API BASE_URL 경로 수정

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,8 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = window.location.hostname === 'localhost'
-  ? 'http://localhost:8080/api/'
-  : '/api/'  //배포수 수정 예정
+const API_BASE_URL = window.location.hostname === 'http://dailygrowth.shop/api/'  //배포수 수정 예정
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,

--- a/frontend/src/data/apiConfig.js
+++ b/frontend/src/data/apiConfig.js
@@ -3,9 +3,9 @@ const getBaseUrl = () => {
   if (import.meta.env.VITE_API_URL) return import.meta.env.VITE_API_URL;
 
   // 2. 로컬 개발 환경 자동 감지
-  if (window.location.hostname === "localhost") {
-    return "http://localhost:8080"; // 백엔드 포트 직접 호출
-  }
+  // if (window.location.hostname === "localhost") {
+  //   return "http://localhost:8080"; // 백엔드 포트 직접 호출
+  // }
 
   // 3. 운영 서버일 경우 현재 origin 사용
   return `${window.location.protocol}//${window.location.host}`;


### PR DESCRIPTION
## 개요
1. 로컬과 배포 환경에서의 BASE_URL 설정을 조정한다.
2. 기본 URL을 `http://dailygrowth.shop/api/`로 명시한다.
3. 불필요한 주석을 제거하며 코드 정리한다.

Resolves #198

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/Git-1a10cae5674e813f8c60ebb4a8f99ca4?pvs=4#1aa0cae5674e807aa012d921c8fa6fe4) 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
