### PR TITLE
fix: Project 엔터티의 Color 관계 매핑 수정

### DIFF
--- a/backend/src/main/java/com/todoservice/greencatsoftware/domain/project/domain/entity/Project.java
+++ b/backend/src/main/java/com/todoservice/greencatsoftware/domain/project/domain/entity/Project.java
@@ -23,7 +23,7 @@ public class Project extends SuperEntity {
     private Long id;
 
     @NotNull(message = "color_id는 필수 입니다.")
-    @OneToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
             name = "color_id", nullable = false,
             foreignKey = @ForeignKey(name = "FK_PROJECT_COLOR")


### PR DESCRIPTION
## 개요
1. color_id 필드의 관계를 @OneToOne에서 @ManyToOne으로 수정.
2. FetchType을 EAGER에서 LAZY로 변경하여 필요 시점에 로드하도록 개선.

Resolves #248

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/Git-1a10cae5674e813f8c60ebb4a8f99ca4?pvs=4#1aa0cae5674e807aa012d921c8fa6fe4) 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
