### PR TITLE
feat: 유저정보 표현을 위해 OAuthController의 /me 로직 수정

### DIFF
--- a/backend/src/main/java/com/todoservice/greencatsoftware/domain/auth/domain/oauth/vo/UserProfileResponse.java
+++ b/backend/src/main/java/com/todoservice/greencatsoftware/domain/auth/domain/oauth/vo/UserProfileResponse.java
@@ -1,0 +1,18 @@
+package com.todoservice.greencatsoftware.domain.auth.domain.oauth.vo;
+
+import com.todoservice.greencatsoftware.domain.member.domain.entity.Member;
+
+public record UserProfileResponse (
+        String name,
+        String email,
+        String profileImageUrl,
+        String providerId
+) {
+    public static UserProfileResponse from(Member member) {
+        return new UserProfileResponse(
+                member.getName(),
+                member.getEmail(),
+                member.getProfileImageUrl(),
+                member.getProviderId());
+    }
+}

--- a/backend/src/main/java/com/todoservice/greencatsoftware/domain/auth/presentation/OAuthController.java
+++ b/backend/src/main/java/com/todoservice/greencatsoftware/domain/auth/presentation/OAuthController.java
@@ -8,11 +8,15 @@ import com.todoservice.greencatsoftware.config.security.token.TokenResponse;
 import com.todoservice.greencatsoftware.domain.auth.application.AuthService;
 import com.todoservice.greencatsoftware.domain.auth.domain.oauth.port.OAuthService;
 import com.todoservice.greencatsoftware.domain.auth.domain.oauth.vo.OAuthUserInfo;
+import com.todoservice.greencatsoftware.domain.auth.domain.oauth.vo.UserProfileResponse;
+import com.todoservice.greencatsoftware.domain.member.application.MemberService;
+import com.todoservice.greencatsoftware.domain.member.domain.entity.Member;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -25,6 +29,7 @@ import java.util.Map;
 public class OAuthController {
     private final Map<String, OAuthService> oAuthServices;
     private final AuthService authService;
+    private final MemberService memberService;
 
     @GetMapping("login/{provider}")
     public void redirectToProvider(@PathVariable String provider, HttpServletResponse response) throws IOException {
@@ -59,11 +64,12 @@ public class OAuthController {
     }
 
     @GetMapping("/me")
-    public BaseResponse<Object> me(Authentication authentication) {
-        if (authentication == null) {
+    public BaseResponse<UserProfileResponse> me(@AuthenticationPrincipal User user) {
+        if (user == null) {
             return new BaseResponse<>(BaseResponseStatus.ACCESS_TOKEN_IS_NULL);
         }
-        return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+        Member memberByIdOrThrow = memberService.getMemberByIdOrThrow(Long.parseLong(user.getUsername()));
+        return new BaseResponse<>(UserProfileResponse.from(memberByIdOrThrow));
     }
 }
 

--- a/backend/src/main/java/com/todoservice/greencatsoftware/domain/member/application/MemberService.java
+++ b/backend/src/main/java/com/todoservice/greencatsoftware/domain/member/application/MemberService.java
@@ -22,6 +22,6 @@ public class MemberService {
 
     public Member getMemberByIdOrThrow(Long id) {
         return memberRepository.getMemberByIdOrThrow(id)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.MISSING_START_TIME_VALUE));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_MEMBER));
     }
 }


### PR DESCRIPTION
## 개요
1. 사용자 프로필 정보를 포괄하는 UserProfileResponse 클래스 생성.
2. OAuthContoller`/me` API에서 UserProfileResponse 객체를 응답으로 제공.
3. MemberService의 getMemberByIdOrThrow메서드의 MISSING_START_TIME_VALUE -> NOT_FOUND_MEMBER로 변경

Resolves: #256

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/Git-1a10cae5674e813f8c60ebb4a8f99ca4?pvs=4#1aa0cae5674e807aa012d921c8fa6fe4) 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
