### PR TITLE
refactor: 챌린지 참여를 위한 도메인 모델 책임 분리

### DIFF
--- a/backend/src/main/java/com/todoservice/dailygrowth/common/baseResponse/BaseResponseStatus.java
+++ b/backend/src/main/java/com/todoservice/dailygrowth/common/baseResponse/BaseResponseStatus.java
@@ -63,11 +63,14 @@ public enum BaseResponseStatus {
     CHALLENGE_COMPLETED(false, 6507, "이미 완료된 프로젝트 입니다."),
     CHALLENGE_CANNOT_BE_PRIVATE(false, 6508, "Challenge는 개인 프로젝트이면 안됩니다."),
     CHALLENGE_CANNOT_BE_NO_PUBLIC(false, 6509, "Challenge는 비공개이면 안됩니다."),
-    CANNOT_JOIN_FULL_CHALLENGE(false, 6510, "챌린지가 가득 차서 참여할 수 없습니다."),
     INVALID_CHALLENGE_CAPACITY(false, 6511, "정원은 0명 이상이여야 합니다."),
     INVALID_CHALLENGE_PARTICIPANT_COUNT(false, 6512, "참여자는 0명 이상이여야 합니다."),
     MISSING_CHALLENGE_DETAILS(false, 6513, "ChallengeDetails가 null입니다."),
     CHALLENGE_DETAILS_NOT_ALLOWED_FOR_NON_CHALLENGE(false, 6514, "ProjectType.PERSONAL은 ChallengeDetails가 null이어야 합니다."),
+    CHALLENGE_FULL(false, 6515, "Challenge 참여인원이 꽉 찼습니다."),
+    ALREADY_PARTICIPATING_IN_CHALLENGE(false, 6516, "Challenge에 이미 참여중입니다."),
+    PARTICIPANT_NOT_FOUND_INT_CHALLENGE(false, 6517, "Challenge에 참여자 명단에 없는 회원입니다."),
+    CHALLENGE_OWNER_CANNOT_LEAVE(false, 6518, "Challenge 소유주는 나갈 수 없습니다."),
 
     /**
      * 7000: Task 오류

--- a/backend/src/main/java/com/todoservice/dailygrowth/domain/challenge/domain/entity/Challenge.java
+++ b/backend/src/main/java/com/todoservice/dailygrowth/domain/challenge/domain/entity/Challenge.java
@@ -58,17 +58,50 @@ public class Challenge extends Project {
      **/
     static public Challenge create(Color color, Member member, String name, Status status, Period period,
                             String description, ChallengeDetails challengeDetails) {
-        return new Challenge(color, member, name, status, period, description, challengeDetails);
+        Challenge challenge = new Challenge(color, member, name, status, period, description, challengeDetails);
+        challenge.addParticipant(member);
+        return challenge;
     }
 
     public void addParticipant(Member member) {
+        //1. 이미 완료된 프로젝트인지 확인
+        if (this.getStatus() == Status.COMPLETED) {
+            throw new BaseException(BaseResponseStatus.CHALLENGE_COMPLETED);
+        }
+
+        //2. 이미 참여한 챌린지인지 검증
+        if (this.participants.stream().anyMatch(p -> p.getMember().getId().equals(member.getId()))) {
+            throw new BaseException(BaseResponseStatus.ALREADY_PARTICIPATING_IN_CHALLENGE);
+        }
+
+        //3. 최대 수용인원보다 현재 참여자 사이즈가 크거나 같은지 확인
+        if (challengeDetails.isFull()) {
+            throw new BaseException(BaseResponseStatus.CHALLENGE_FULL);
+        }
+
         ChallengeParticipant challengeParticipant = ChallengeParticipant.create(this, member);
         participants.add(challengeParticipant);
         challengeDetails = challengeDetails.increaseParticipant();
     }
 
-    public void removeParticipant(ChallengeParticipant participant) {
-        this.participants.remove(participant);
+    public void removeParticipant(Member member) {
+        //1. 이미 완료된 프로젝트인지 확인
+        if (this.getStatus() == Status.COMPLETED) {
+            throw new BaseException(BaseResponseStatus.CHALLENGE_COMPLETED);
+        }
+
+        //2. 참여자 목록에 있는 사람인지 확인
+        ChallengeParticipant challengeParticipant = this.participants.stream()
+                .filter(p -> p.getMember().getId().equals(member.getId()))
+                .findFirst()
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.PARTICIPANT_NOT_FOUND_INT_CHALLENGE));
+
+        //3. 챌린지 소유자는 나갈 수 없다. (챌린지 소유자가 나가면 Challenge 인스턴스를 삭제)
+        if (this.getMember().getId().equals(member.getId())) {
+            throw new BaseException(BaseResponseStatus.CHALLENGE_OWNER_CANNOT_LEAVE);
+        }
+
+        this.participants.remove(challengeParticipant);
         challengeDetails = challengeDetails.decreaseParticipant();
     }
 }

--- a/backend/src/main/java/com/todoservice/dailygrowth/domain/challenge/domain/entity/ChallengeParticipant.java
+++ b/backend/src/main/java/com/todoservice/dailygrowth/domain/challenge/domain/entity/ChallengeParticipant.java
@@ -1,7 +1,6 @@
 package com.todoservice.dailygrowth.domain.challenge.domain.entity;
 
 import com.todoservice.dailygrowth.common.baseResponse.BaseResponseStatus;
-import com.todoservice.dailygrowth.common.enums.Status;
 import com.todoservice.dailygrowth.common.exception.BaseException;
 import com.todoservice.dailygrowth.common.superEntity.SuperEntity;
 import com.todoservice.dailygrowth.domain.member.domain.entity.Member;
@@ -41,14 +40,14 @@ public class ChallengeParticipant extends SuperEntity {
     @Column(nullable = false, updatable = false)
     private LocalDateTime joinedDateTime;
 
-    public ChallengeParticipant(Challenge challenge, Member member, LocalDateTime joinedDateTime) {
-        validateDomainInvariants(challenge, member, joinedDateTime);
+    public ChallengeParticipant(Challenge challenge, Member member) {
+        validateDomainInvariants(challenge, member);
         this.challenge = challenge;
         this.member = member;
-        this.joinedDateTime = joinedDateTime;
+        this.joinedDateTime = LocalDateTime.now();
     }
 
-    private void validateDomainInvariants(Challenge challenge, Member member, LocalDateTime joinedDateTime) {
+    private void validateDomainInvariants(Challenge challenge, Member member) {
         //1. 기본 null 확인
         if (challenge == null) {
             throw new BaseException(BaseResponseStatus.MISSING_PROJECT_FOR_CHALLENGE);
@@ -56,36 +55,28 @@ public class ChallengeParticipant extends SuperEntity {
         if (member == null) {
             throw new BaseException(BaseResponseStatus.MISSING_MEMBER_FOR_CHALLENGE);
         }
-        //todo: 3. 회원이 이미 참여했는지 확인
 
-        //todo: 4. 챌린지가 가득 찼는지 확인
-
-        //5. 날짜 유효성 검사
         if (challenge.getPeriod() == null || challenge.getPeriod().isNull()) {
             throw new BaseException(BaseResponseStatus.CHALLENGE_PERIOD_UNDEFINED);
         }
 
-        LocalDate joinedDate = joinedDateTime.toLocalDate();
+        //2. 날짜 유효성 검사
+        LocalDate joinedDate = LocalDate.now();
         LocalDate start = challenge.getPeriod().startDate();
         LocalDate end = challenge.getPeriod().endDate();
 
-        //5-1. joinedDateTime이 시작 날짜보다 이전인지 확인
+        //2-1. joinedDateTime이 시작 날짜보다 이전인지 확인
         if (joinedDate.isBefore(start)) {
             throw new BaseException(BaseResponseStatus.CHALLENGE_NOT_START);
         }
 
-        //5-2. joinedDateTime이 종료 날짜보다 이후인지 확인
+        //2-2. joinedDateTime이 종료 날짜보다 이후인지 확인
         if (end != null && joinedDate.isAfter(end)) {
             throw new BaseException(BaseResponseStatus.CHALLENGE_ENDED);
-        }
-
-        //6. 이미 완료된 프로젝트인지 확인
-        if (challenge.getStatus() == Status.COMPLETED) {
-            throw new BaseException(BaseResponseStatus.CHALLENGE_COMPLETED);
         }
     }
 
     static public ChallengeParticipant create(Challenge challenge, Member member) {
-        return new ChallengeParticipant(challenge, member, LocalDateTime.now());
+        return new ChallengeParticipant(challenge, member);
     }
 }

--- a/backend/src/main/java/com/todoservice/dailygrowth/domain/challenge/domain/vo/ChallengeDetails.java
+++ b/backend/src/main/java/com/todoservice/dailygrowth/domain/challenge/domain/vo/ChallengeDetails.java
@@ -8,11 +8,11 @@ import jakarta.persistence.Embeddable;
 @Embeddable
 public record ChallengeDetails(
         Integer participantCount,
-        Integer targetParticipants,
+        Integer maxParticipant,
         ChallengeCategory challengeCategory
 ) {
     public ChallengeDetails {
-        validationChallengeDetails(participantCount, targetParticipants, challengeCategory);
+        validationChallengeDetails(participantCount, maxParticipant, challengeCategory);
     }
 
     private void validationChallengeDetails(int participantCount, int targetParticipants, ChallengeCategory challengeCategory) {
@@ -20,38 +20,34 @@ public record ChallengeDetails(
             throw new BaseException(BaseResponseStatus.INVALID_CHALLENGE_CAPACITY);
         }
 
-        if (participantCount <= 0) {
-            throw new BaseException(BaseResponseStatus.INVALID_CHALLENGE_PARTICIPANT_COUNT);
-        }
-
         if (targetParticipants < participantCount) {
-            throw new BaseException(BaseResponseStatus.CANNOT_JOIN_FULL_CHALLENGE);
+            throw new BaseException(BaseResponseStatus.CHALLENGE_FULL);
         }
     }
 
     static public ChallengeDetails of(int targetParticipants, ChallengeCategory challengeCategory) {
-        return new ChallengeDetails(1, targetParticipants, challengeCategory);
+        return new ChallengeDetails(0, targetParticipants, challengeCategory);
     }
 
     public ChallengeDetails increaseParticipant() {
-        if (participantCount + 1 > targetParticipants) {
-            throw new BaseException(BaseResponseStatus.CANNOT_JOIN_FULL_CHALLENGE);
+        if (participantCount + 1 > maxParticipant) {
+            throw new BaseException(BaseResponseStatus.CHALLENGE_FULL);
         }
-        return new ChallengeDetails(participantCount + 1, targetParticipants, challengeCategory);
+        return new ChallengeDetails(participantCount + 1, maxParticipant, challengeCategory);
     }
 
     public ChallengeDetails decreaseParticipant() {
         if (participantCount - 1 < 0) {
             throw new BaseException(BaseResponseStatus.INVALID_CHALLENGE_PARTICIPANT_COUNT);
         }
-        return new ChallengeDetails(participantCount - 1, targetParticipants, challengeCategory);
+        return new ChallengeDetails(participantCount - 1, maxParticipant, challengeCategory);
     }
 
     public boolean isFull() {
-        return participantCount == targetParticipants;
+        return participantCount == maxParticipant;
     }
 
     public boolean isNull() {
-        return participantCount == null && targetParticipants == null;
+        return participantCount == null && maxParticipant == null;
     }
 }

--- a/backend/src/test/java/com/todoservice/dailygrowth/domain/challenge/ChallengeTest.java
+++ b/backend/src/test/java/com/todoservice/dailygrowth/domain/challenge/ChallengeTest.java
@@ -1,0 +1,217 @@
+package com.todoservice.dailygrowth.domain.challenge;
+
+import com.todoservice.dailygrowth.common.baseResponse.BaseResponseStatus;
+import com.todoservice.dailygrowth.common.enums.ChallengeCategory;
+import com.todoservice.dailygrowth.common.enums.Status;
+import com.todoservice.dailygrowth.common.exception.BaseException;
+import com.todoservice.dailygrowth.domain.auth.domain.oauth.vo.OAuth2Provider;
+import com.todoservice.dailygrowth.domain.challenge.domain.entity.Challenge;
+import com.todoservice.dailygrowth.domain.challenge.domain.vo.ChallengeDetails;
+import com.todoservice.dailygrowth.domain.color.entity.Color;
+import com.todoservice.dailygrowth.domain.member.domain.entity.Member;
+import com.todoservice.dailygrowth.domain.project.domain.vo.Period;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ChallengeTest {
+    private static final Logger log = LoggerFactory.getLogger(ChallengeTest.class);
+    private Member member;
+    private Challenge challenge;
+
+    @BeforeEach
+    public void createChallengeParticipant() throws Exception {
+        //given
+        member = Member.create(
+                "member1@test.com",
+                OAuth2Provider.KAKAO,
+                "asevanoeqointqewr123",
+                "12345",
+                "null",
+                "testName");
+        ReflectionTestUtils.setField(member, "id", 1L);
+        LocalDate startDate = LocalDate.now().minusDays(1);
+        LocalDate endDate = LocalDate.now().plusDays(1);
+        Color color = Color.create("RED", "FF0000");
+        Period period = Period.of(startDate, endDate, null);
+        ChallengeDetails challengeDetails = ChallengeDetails.of(2, ChallengeCategory.WORKOUT);
+
+        challenge = Challenge.create(
+                color,
+                member,
+                "   나의 프로젝트    ",
+                Status.PLANNING,
+                period,
+                "   잘해보자구~",
+                challengeDetails);
+
+    }
+    //todo: challenge와 challengeDetails, 고유메서드 테스트 코드 작성(아래 모두 제거 후 수정해야함)
+    @Test
+    @DisplayName("검증 실패: project period가 null이면 BaseException 반환")
+    public void create_fail_validation_project_period_is_null() throws Exception {
+        //given
+        Color color = Color.create("RED", "FF0000");
+        ChallengeDetails challengeDetails = ChallengeDetails.of(3, ChallengeCategory.WORKOUT);
+
+        //when
+        assertThatThrownBy(() -> Challenge.create(
+                color,
+                member,
+                "   나의 프로젝트    ",
+                Status.PLANNING,
+                null,
+                "   잘해보자구~",
+                challengeDetails))
+                .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.CHALLENGE_PERIOD_UNDEFINED.getMessage());
+    }
+
+    @Test
+    @DisplayName("검증 실패: challenge addParticipant에서 status.COMPLETE이면 BaseException 반환")
+    public void challenge_addParticipant_fail_validation_status() throws Exception {
+        //given
+        challenge.changeStatus(Status.COMPLETED);
+
+        Member newMember = Member.create(
+                "member2@test.com",
+                OAuth2Provider.KAKAO,
+                "asevanoeqointqewr456",
+                "12345",
+                "null",
+                "testName2");
+
+        //when
+        assertThatThrownBy(() -> challenge.addParticipant(newMember))
+                .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.CHALLENGE_COMPLETED.getMessage());
+    }
+
+    @Test
+    @DisplayName("검증 실패: challenge addParticipant에서 인원이 초과된 상태이면 BaseException 반환")
+    public void challenge_addParticipant_fail_validation_participant_over() throws Exception {
+        //given
+        Member member1 = Member.create(
+                "member2@test.com",
+                OAuth2Provider.KAKAO,
+                "asevanoeqointqewr456",
+                "12345",
+                "null",
+                "testName2");
+
+        Member member2 = Member.create(
+                "member3@test.com",
+                OAuth2Provider.KAKAO,
+                "asevanoeqointqewr789",
+                "12345",
+                "null",
+                "testName3");
+        ReflectionTestUtils.setField(member1, "id", 2L);
+        ReflectionTestUtils.setField(member2, "id", 3L);
+
+        //when
+        challenge.addParticipant(member1);
+
+        //then
+        assertThatThrownBy(() -> challenge.addParticipant(member2))
+                .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.CHALLENGE_FULL.getMessage());
+    }
+
+    @Test
+    @DisplayName("검증 실패: challenge addParticipant에서 이미 참여한 상태이면 BaseException 반환")
+    public void challenge_addParticipant_fail_validation_already() throws Exception {
+        //then
+        assertThatThrownBy(() -> challenge.addParticipant(member))
+                .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.ALREADY_PARTICIPATING_IN_CHALLENGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("성공: challenge addParticipant에 성공")
+    public void challenge_addParticipant_success() throws Exception {
+        //given
+        Member member1 = Member.create(
+                "member2@test.com",
+                OAuth2Provider.KAKAO,
+                "asevanoeqointqewr456",
+                "12345",
+                "null",
+                "testName2");
+        ReflectionTestUtils.setField(member1, "id", 2L);
+
+        //when & then
+        assertThat(challenge.getParticipants().size()).isEqualTo(1);
+        challenge.addParticipant(member1);
+        assertThat(challenge.getParticipants().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("검증 실패: challenge removeParticipant에서 status.COMPLETE라면 BaseException 반환")
+    public void challenge_removeParticipant_fail_validation_status_complete() throws Exception {
+        Member member1 = Member.create(
+                "member2@test.com",
+                OAuth2Provider.KAKAO,
+                "asevanoeqointqewr456",
+                "12345",
+                "null",
+                "testName2");
+        ReflectionTestUtils.setField(member1, "id", 2L);
+
+        //when
+        challenge.addParticipant(member1);
+        challenge.changeStatus(Status.COMPLETED);
+        //then
+        assertThatThrownBy(() -> challenge.removeParticipant(member1))
+                .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.CHALLENGE_COMPLETED.getMessage());
+    }
+
+    @Test
+    @DisplayName("검증 실패: challenge removeParticipant에서 참여자 목록에 없는 사용자라면 BaseException 반환")
+    public void challenge_removeParticipant_fail_validation_not_found() throws Exception {
+        Member member1 = Member.create(
+                "member2@test.com",
+                OAuth2Provider.KAKAO,
+                "asevanoeqointqewr456",
+                "12345",
+                "null",
+                "testName2");
+        ReflectionTestUtils.setField(member1, "id", 2L);
+
+        //then
+        assertThatThrownBy(() -> challenge.removeParticipant(member1))
+                .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.PARTICIPANT_NOT_FOUND_INT_CHALLENGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("검증 실패: challenge removeParticipant에서 소유자가 나가려고 하면 BaseException 반환")
+    public void challenge_removeParticipant_fail_validation_is_owner() throws Exception {
+        //then
+        assertThatThrownBy(() -> challenge.removeParticipant(member))
+                .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.CHALLENGE_OWNER_CANNOT_LEAVE.getMessage());
+    }
+
+    @Test
+    @DisplayName("성공: challenge removeParticipant에 성공")
+    public void challenge_removeParticipant_success() throws Exception {
+        Member member1 = Member.create(
+                "member2@test.com",
+                OAuth2Provider.KAKAO,
+                "asevanoeqointqewr456",
+                "12345",
+                "null",
+                "testName2");
+        ReflectionTestUtils.setField(member1, "id", 2L);
+
+        //when & then
+        challenge.addParticipant(member1);
+        assertThat(challenge.getParticipants().size()).isEqualTo(2);
+
+        challenge.removeParticipant(member1);
+        assertThat(challenge.getParticipants().size()).isEqualTo(1);
+    }
+}

--- a/backend/src/test/java/com/todoservice/dailygrowth/domain/challengeParticipant/ChallengeParticipantTest.java
+++ b/backend/src/test/java/com/todoservice/dailygrowth/domain/challengeParticipant/ChallengeParticipantTest.java
@@ -70,7 +70,7 @@ public class ChallengeParticipantTest {
         assertThat(challengeParticipant.getChallenge().getColor().getName()).isEqualTo("RED");
         assertThat(challengeParticipant.getChallenge().getChallengeDetails().challengeCategory()).isEqualTo(ChallengeCategory.WORKOUT);
         assertThat(challengeParticipant.getChallenge().getChallengeDetails().participantCount()).isEqualTo(1);
-        assertThat(challengeParticipant.getChallenge().getChallengeDetails().targetParticipants()).isEqualTo(3);
+        assertThat(challengeParticipant.getChallenge().getChallengeDetails().maxParticipant()).isEqualTo(3);
 
     }
 
@@ -88,33 +88,7 @@ public class ChallengeParticipantTest {
     }
 
     @Test
-    @DisplayName("검증 실패: project period가 null이면 BaseException 반환")
-    public void create_fail_validation_project_period_is_null() throws Exception {
-        //given
-        member = Member.create(
-                "member1@test.com",
-                OAuth2Provider.KAKAO,
-                "asevanoeqointqewr123",
-                "12345",
-                "null",
-                "testName");
-        Color color = Color.create("RED", "FF0000");
-        ChallengeDetails challengeDetails = ChallengeDetails.of(3, ChallengeCategory.WORKOUT);
-
-        //when
-        assertThatThrownBy(() -> Challenge.create(
-                color,
-                member,
-                "   나의 프로젝트    ",
-                Status.PLANNING,
-                null,
-                "   잘해보자구~",
-                challengeDetails))
-                .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.CHALLENGE_PERIOD_UNDEFINED.getMessage());
-    }
-
-    @Test
-    @DisplayName("검증 실패: project period가 시작 전이면 BaseException 반환")
+    @DisplayName("검증 실패: joinedDateTime이 시작 날짜보다 이전이면 BaseException 반환")
     public void create_fail_validation_project_period_before_start () throws Exception {
         //given
         LocalDate changeStart = LocalDate.now().plusDays(1);
@@ -139,65 +113,5 @@ public class ChallengeParticipantTest {
         //when
         assertThatThrownBy(() -> ChallengeParticipant.create(challenge, member))
                 .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.CHALLENGE_ENDED.getMessage());
-    }
-
-    @Test
-    @DisplayName("검증 실패: project status가 COMPLETE이면 BaseException 반환")
-    public void create_fail_validation_project_status_complete() throws Exception {
-        //given
-        challenge.changeStatus(Status.COMPLETED);
-
-        //when
-        assertThatThrownBy(() -> ChallengeParticipant.create(challenge, member))
-                .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.CHALLENGE_COMPLETED.getMessage());
-    }
-
-    @Test
-    @DisplayName("수정 실패: ChallengeDetails의 participantCount가 targetParticipant보다 크면 BaseException 반환")
-    public void create_fail_validation_challenge_details() throws Exception {
-        //given
-        LocalDate startDate = LocalDate.now().minusDays(1);
-        LocalDate endDate = LocalDate.now().plusDays(1);
-        Color color = Color.create("RED", "FF0000");
-        Period period = Period.of(startDate, endDate, null);
-        ChallengeDetails challengeDetails = ChallengeDetails.of(1, ChallengeCategory.WORKOUT);
-
-        //when
-        Challenge newChallenge = Challenge.create(
-                color,
-                member,
-                "   나의 프로젝트    ",
-                Status.PLANNING,
-                period,
-                "   잘해보자구~",
-                challengeDetails);
-
-        //then
-        assertThatThrownBy(() -> newChallenge.getChallengeDetails().increaseParticipant())
-                .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.CANNOT_JOIN_FULL_CHALLENGE.getMessage());
-    }
-    @Test
-    @DisplayName("수정 실패: ChallengeDetails의 participantCount가 0보다 작으면 BaseException 반환")
-    public void create_fail_validation_challenge_details_decrease() throws Exception {
-        //given
-        LocalDate startDate = LocalDate.now().minusDays(1);
-        LocalDate endDate = LocalDate.now().plusDays(1);
-        Color color = Color.create("RED", "FF0000");
-        Period period = Period.of(startDate, endDate, null);
-        ChallengeDetails challengeDetails = ChallengeDetails.of(1, ChallengeCategory.WORKOUT);
-
-        //when
-        Challenge newChallenge = Challenge.create(
-                color,
-                member,
-                "   나의 프로젝트    ",
-                Status.PLANNING,
-                period,
-                "   잘해보자구~",
-                challengeDetails);
-
-        //then
-        assertThatThrownBy(() -> newChallenge.getChallengeDetails().decreaseParticipant())
-                .isInstanceOf(BaseException.class).hasMessage(BaseResponseStatus.INVALID_CHALLENGE_PARTICIPANT_COUNT.getMessage());
     }
 }


### PR DESCRIPTION
## 개요
챌린지 참여/탈퇴 로직의 도메인 모델 책임을 명확히 하기 위한 리펙토링 진행

기존 ChallengeParticipant에 분산되어 있었던 참여 관련 비즈니스 검증 로직(참여 인원 초과, 중복 참여 등)을 Challenge의 핵심 메서드(addParticipant, removeParticipant)로 이전함.

이를 통해 Challenge 엔티티가 자신의 상태와 관련된 모든 비즈니스 규칙(불변식)을 스스로 책임지도록 하여 객체의 응집도를 높이고, 향후 유지보수가 용이한 개체지향적 구조로 개선함.

Resolves: #290 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/Git-1a10cae5674e813f8c60ebb4a8f99ca4?pvs=4#1aa0cae5674e807aa012d921c8fa6fe4) 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
